### PR TITLE
Support deployment from a local machine

### DIFF
--- a/Terraform/02-network.tf
+++ b/Terraform/02-network.tf
@@ -33,7 +33,7 @@ resource "azurerm_network_security_group" "cloudlabs-nsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "22"
-    source_address_prefixes    = "${concat(var.ip-whitelist, ["${chomp(data.http.public-ip.body)}/32"])}"
+    source_address_prefixes    = "${distinct(concat(var.ip-whitelist, [chomp(data.http.public-ip.body)]))}"
     destination_address_prefix = "*"
   }
 


### PR DESCRIPTION
When specifying the public IP of a local machine in the whitelist, Azure complains since the nsg will have two source IP entries of the same value. This PR ensures the nsg gets an array of unique values. Also removed the /32 for the same purpose.